### PR TITLE
fix: replace deprecated --force-overwrite flag

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -116,7 +116,7 @@ inputs:
       Set value to 'debug' to see additional debug output to help tracking down errors.
     required: false
   ort-cli-args:
-    default: '--force-overwrite --stacktrace'
+    default: '-P ort.forceOverwrite=true --stacktrace'
     description: |
       List of arguments to pass to ORT CLI, applies to all commands.
     required: false


### PR DESCRIPTION
The flag was deprecated earlier and was removed in commit https://github.com/oss-review-toolkit/ort/commit/e906713b587d05efd9b361cd7bc2e5473c0bad97 The suggested alternative is used instead.

Closes #19

Please ensure that your pull request adheres to our [contribution guidelines](https://github.com/oss-review-toolkit/.github/blob/main/CONTRIBUTING.md). Thank you!
