### PR TITLE
docs(README): Fix analyzer enabled managers option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ jobs:
         uses: oss-review-toolkit/ort-ci-github-action@v1
         with:
           allow-dynamic-versions: 'true'
-          ort-cli-analyze-args: '--package-managers NPM,Yarn,Yarn2'
+          ort-cli-analyze-args: '-P ort.analyzer.enabledPackageManagers=NPM,Yarn,Yarn2'
 ```
 
 #### Run ORT with labels


### PR DESCRIPTION
Deprecated "--(not-)package-managers" analyzer options was removed in [1].

[1]: https://github.com/oss-review-toolkit/ort/commit/cb2f5e6a49e0ee226cc515ee437305489f47f1e5

