### PR TITLE
chore(ort-scan): Use ORT's new official (extended) docker image

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -106,7 +106,7 @@ inputs:
       API token for HTTP file server used for caching scan-results and storing file archives.
     required: false
   image:
-    default: 'ghcr.io/alliander-opensource/ort-container:latest'
+    default: 'ghcr.io/oss-review-toolkit/ort-extended:latest'
     description: |
       URL for ORT Docker image to use.
     required: false


### PR DESCRIPTION
Use recently published official ORT docker image instead of the intermediate ORT container published by Alliander's OSPO.

