### PR TITLE
chore(ort-scan): Use renamed ORT Docker image

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -106,7 +106,7 @@ inputs:
       API token for HTTP file server used for caching scan-results and storing file archives.
     required: false
   image:
-    default: 'ghcr.io/oss-review-toolkit/ort-extended:latest'
+    default: 'ghcr.io/oss-review-toolkit/ort:latest'
     description: |
       URL for ORT Docker image to use.
     required: false


### PR DESCRIPTION
The 'ort-extended' Docker image was renamed to just 'ort' in [1].

[1]: https://github.com/oss-review-toolkit/ort/commit/cd323ab55b660edf66d289ff91027afcb4a9723d
