### PR TITLE
Add ORT_HOME_PATH/cache to the locations for the GH cache

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -331,6 +331,8 @@ runs:
       id: cache-dependencies
       uses: actions/cache@v3
       if: contains(inputs.run, 'cache-dependencies') && startsWith(runner.os, 'Linux')
+      env:
+        ORT_HOME_PATH: ${{ inputs.ort-home-path }}
       with:
         path: |
           ~/.cabal/packages
@@ -354,6 +356,7 @@ runs:
           ~/.sbt
           ~/.stack-work
           ~/go/pkg/mod
+          $HOME/$ORT_HOME_PATH/cache
         key: ${{ runner.os }}-ort-deps-cache
     - name: Cache ORT scan results
       id: cache-scan-results


### PR DESCRIPTION
Some package managers store downloaded artifacts in the ORT_HOME_PATH/cache directory for faster access after the first run, one example being the maven package manager. 

Adding the .m2 directory as cache is not sufficient in this case, as the package manager will do a head request for all artifacts all the time unless it is found in the aforementioned cache.

Please ensure that your pull request adheres to our [contribution guidelines](https://github.com/oss-review-toolkit/.github/blob/main/CONTRIBUTING.md). Thank you!
