### PR TITLE
Update github actions cache and upload-artifact to v4 with NodeJS 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -329,7 +329,7 @@ runs:
         printenv >> "$GITHUB_ENV"
     - name: Cache dependencies
       id: cache-dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       if: contains(inputs.run, 'cache-dependencies') && startsWith(runner.os, 'Linux')
       with:
         path: |
@@ -357,7 +357,7 @@ runs:
         key: ${{ runner.os }}-ort-deps-cache
     - name: Cache ORT scan results
       id: cache-scan-results
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       if: contains(inputs.run, 'cache-scan-results') && startsWith(runner.os, 'Linux')
       with:
         path: '${{ env.HOME}}/${{ env.ORT_HOME_PATH }}/scanner/'
@@ -543,28 +543,28 @@ runs:
             rm -f $ORT_RESULTS_CURRENT_PATH
         fi
     - name: Upload ORT results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: contains(inputs.run, 'upload-results')
       with:
         name: ${{ env.ORT_RESULTS_ARTIFACT_NAME }}
         path: ${{ env.ORT_RESULTS_PATH }}
         if-no-files-found: warn
     - name: Upload ORT advisor-result.json
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: contains(inputs.run, 'upload-advisor-result')
       with:
         name: "${{ env.ORT_RESULTS_ARTIFACT_NAME }}-advisor-result.json.zip"
         path: ${{ env.ORT_RESULTS_ADVISOR_PATH }}
         if-no-files-found: warn
     - name: Upload ORT evaluation-result.json
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: contains(inputs.run, 'upload-evaluation-result')
       with:
         name: "${{ env.ORT_RESULTS_ARTIFACT_NAME }}-evaluation-result.json.zip"
         path: ${{ env.ORT_RESULTS_EVALUATE_PATH }}
         if-no-files-found: warn
     - name: Upload ORT scan-result.json
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: contains(inputs.run, 'upload-scan-result')
       with:
         name: "${{ env.ORT_RESULTS_ARTIFACT_NAME }}-scan-result.json.zip"


### PR DESCRIPTION
Actions using NodeJS 16 are deprecated.

This PR solved the following warning message:

`Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/cache@v3, actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.`