### PR TITLE
fix: remove removed Java Option `illegal-access`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -385,7 +385,7 @@ runs:
         docker run \
         --mount type=bind,source=$HOME,target=/home/ort \
         -u $(id -u):$(id -g) \
-        -e JDK_JAVA_OPTIONS="--illegal-access=warn -Xmx5120m" \
+        -e JDK_JAVA_OPTIONS="-Xmx5120m" \
         -e ORT_DATA_DIR="/home/ort/${ORT_HOME_PATH}" \
         $ORT_DOCKER_CLI_ARGS \
         $ORT_DOCKER_IMAGE \
@@ -405,7 +405,7 @@ runs:
         docker run \
         --mount type=bind,source=$HOME,target=/home/ort \
         -u $(id -u):$(id -g) \
-        -e JDK_JAVA_OPTIONS="--illegal-access=warn -Xmx5120m" \
+        -e JDK_JAVA_OPTIONS="-Xmx5120m" \
         -e ORT_DATA_DIR="/home/ort/${ORT_HOME_PATH}" \
         $ORT_DOCKER_CLI_ARGS \
         $ORT_DOCKER_IMAGE \
@@ -434,7 +434,7 @@ runs:
         --mount type=bind,source=$HOME,target=/home/ort \
         --mount type=tmpfs,target=/tmp \
         -v ${SSH_AUTH_SOCK}:/ssh.socket \
-        -e JDK_JAVA_OPTIONS="--illegal-access=warn -Xmx5120m" \
+        -e JDK_JAVA_OPTIONS="-Xmx5120m" \
         -e ORT_DATA_DIR="/home/ort/${ORT_HOME_PATH}" \
         -e HTTP_FILE_SERVER_PASSWORD="${HTTP_FILE_SERVER_PASSWORD}" \
         -e HTTP_FILE_SERVER_TOKEN="${HTTP_FILE_SERVER_TOKEN}" \
@@ -468,7 +468,7 @@ runs:
         echo -e "\e[1;33m Running ORT Advisor... "
         docker run \
         --mount type=bind,source=$HOME,target=/home/ort \
-        -e JDK_JAVA_OPTIONS="--illegal-access=warn -Xmx5120m" \
+        -e JDK_JAVA_OPTIONS="-Xmx5120m" \
         -e ORT_DATA_DIR="/home/ort/${ORT_HOME_PATH}" \
         -u $(id -u):$(id -g) \
         $ORT_DOCKER_CLI_ARGS \
@@ -495,7 +495,7 @@ runs:
         echo -e "\e[1;33m Running ORT Evaluator... "
         docker run \
         --mount type=bind,source=$HOME,target=/home/ort \
-        -e JDK_JAVA_OPTIONS="--illegal-access=warn -Xmx5120m" \
+        -e JDK_JAVA_OPTIONS="-Xmx5120m" \
         -e ORT_DATA_DIR="/home/ort/${ORT_HOME_PATH}" \
         -u $(id -u):$(id -g) \
         $ORT_DOCKER_CLI_ARGS \
@@ -524,7 +524,7 @@ runs:
         echo -e "\e[1;33m Running ORT Reporter... "
         docker run \
         --mount type=bind,source=$HOME,target=/home/ort \
-        -e JDK_JAVA_OPTIONS="--illegal-access=warn -Xmx5120m" \
+        -e JDK_JAVA_OPTIONS="-Xmx5120m" \
         -e ORT_DATA_DIR="/home/ort/${ORT_HOME_PATH}" \
         -e POSTGRES_URL="${POSTGRES_URL}" \
         -e POSTGRES_USERNAME="${POSTGRES_USERNAME}" \


### PR DESCRIPTION
Resolves the following warnings:

```
NOTE: Picked up JDK_JAVA_OPTIONS: --illegal-access=warn -Xmx5120m
OpenJDK 64-Bit Server VM warning: Ignoring option --illegal-access=warn; support was removed in 17.0
```

* [x] Please ensure that your pull request adheres to our [contribution guidelines](https://github.com/oss-review-toolkit/.github/blob/main/CONTRIBUTING.md). Thank you!
